### PR TITLE
Add automated layout and logic tests

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,10 +1,10 @@
-const STORAGE_KEYS = {
+export const STORAGE_KEYS = {
   accounts: 'stratasphere_accounts_v1',
   active: 'stratasphere_active_v1',
   session: 'stratasphere_session_v1',
 };
 
-const RESOURCE_DEFS = {
+export const RESOURCE_DEFS = {
   iron: {
     name: 'Eisen',
     baseRate: 16,
@@ -47,7 +47,7 @@ const RESOURCE_DEFS = {
   },
 };
 
-const GUILD_TECHS = [
+export const GUILD_TECHS = [
   {
     id: 'synergy_drills',
     name: 'Synergiebohrer',
@@ -74,7 +74,7 @@ const GUILD_TECHS = [
   },
 ];
 
-const RESEARCH_DEFS = [
+export const RESEARCH_DEFS = [
   {
     id: 'automation',
     name: 'Adaptive Automatisierung',
@@ -109,7 +109,7 @@ const RESEARCH_DEFS = [
   },
 ];
 
-const INITIAL_STATE = () => ({
+export const INITIAL_STATE = () => ({
   credits: 5000,
   researchPoints: 120,
   day: 1,
@@ -147,7 +147,7 @@ const generateId = () => {
 
 const toRadians = (degrees) => (degrees * Math.PI) / 180;
 
-const createCircularPolygon = (center, radiusKm, segments = 24) => {
+export const createCircularPolygon = (center, radiusKm, segments = 24) => {
   const points = [];
   const earthRadiusKm = 6371;
   for (let i = 0; i < segments; i += 1) {
@@ -169,7 +169,7 @@ const createCircularPolygon = (center, radiusKm, segments = 24) => {
   return points;
 };
 
-const pointInPolygon = (point, polygon) => {
+export const pointInPolygon = (point, polygon) => {
   const [lat, lng] = point;
   let inside = false;
   for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i, i += 1) {
@@ -184,7 +184,7 @@ const pointInPolygon = (point, polygon) => {
   return inside;
 };
 
-class RemoteGateway {
+export class RemoteGateway {
   constructor(baseUrl = 'server/api.php') {
     this.baseUrl = baseUrl;
   }
@@ -265,7 +265,7 @@ class RemoteGateway {
   }
 }
 
-class AccountStore {
+export class AccountStore {
   constructor(storage, remoteGateway) {
     this.storage = storage;
     this.remote = remoteGateway;
@@ -481,7 +481,7 @@ class AccountStore {
   }
 }
 
-class Toast {
+export class Toast {
   constructor() {
     this.element = document.createElement('div');
     this.element.className = 'toast';
@@ -498,7 +498,7 @@ class Toast {
   }
 }
 
-class GameEngine {
+export class GameEngine {
   constructor(account, accountStore, toast) {
     this.account = account;
     this.accountStore = accountStore;
@@ -1118,6 +1118,7 @@ class GameEngine {
         const maxY = bounds.height - windowEl.offsetHeight - 12;
         windowEl.style.left = `${Math.max(12, Math.min(targetX, maxX))}px`;
         windowEl.style.top = `${Math.max(12, Math.min(targetY, maxY))}px`;
+      };
 
       header.addEventListener('mousedown', (event) => {
         if (window.innerWidth < 1024) return;
@@ -1625,7 +1626,7 @@ class GameEngine {
   }
 }
 
-class App {
+export class App {
   constructor() {
     this.accountStore = new AccountStore(window.localStorage, new RemoteGateway());
     this.toast = new Toast();
@@ -1765,6 +1766,10 @@ class App {
   }
 }
 
-window.addEventListener('DOMContentLoaded', () => {
-  new App();
-});
+export const bootstrapApp = () => new App();
+
+if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+  window.addEventListener('DOMContentLoaded', () => {
+    bootstrapApp();
+  });
+}

--- a/index.html
+++ b/index.html
@@ -406,40 +406,6 @@
               </section>
             </div>
           </div>
-=======
-        <div class="ui-window" id="status-window">
-          <div class="window-header">
-            <h2>Status</h2>
-            <div class="window-actions">
-              <button class="window-minimize" aria-label="Minimieren">–</button>
-            </div>
-          </div>
-          <div class="window-body">
-            <p><strong>Zeit:</strong> <span id="time-display"></span></p>
-            <p><strong>Credits:</strong> <span id="credits-display"></span></p>
-            <p><strong>Forschung:</strong> <span id="research-display"></span></p>
-            <div class="resource-list" id="resource-list"></div>
-          </div>
-        </div>
-
-        <div class="ui-window" id="mine-window">
-          <div class="window-header">
-            <h2>Minen</h2>
-            <div class="window-actions">
-              <button class="window-minimize" aria-label="Minimieren">–</button>
-            </div>
-          </div>
-          <div class="window-body">
-            <p>
-              Klicke auf die Weltkarte, um eine neue Mine zu platzieren. Jede Mine kann
-              Upgrades, Belegschaft und Logistik erhalten.
-            </p>
-            <div id="mine-list"></div>
-          </div>
-        </div>
-
-        <div class="ui-window" id="logistics-window">
-          <div class="window-header"
         </div>
       </div>
     </div>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "miningadventure",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test tests/*.test.mjs && python tests/validate_layout.py"
+  }
+}

--- a/tests/accountStore.test.mjs
+++ b/tests/accountStore.test.mjs
@@ -1,0 +1,93 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AccountStore, INITIAL_STATE, STORAGE_KEYS } from '../assets/js/main.js';
+
+if (typeof globalThis.btoa !== 'function') {
+  globalThis.btoa = (value) => Buffer.from(String(value), 'utf8').toString('base64');
+}
+
+class MemoryStorage {
+  constructor(initial = {}) {
+    this.map = new Map(Object.entries(initial));
+  }
+
+  getItem(key) {
+    return this.map.has(key) ? this.map.get(key) : null;
+  }
+
+  setItem(key, value) {
+    this.map.set(key, String(value));
+  }
+
+  removeItem(key) {
+    this.map.delete(key);
+  }
+}
+
+test('registerLocal persists a new account with hashed password', () => {
+  const storage = new MemoryStorage();
+  const store = new AccountStore(storage, null);
+  const result = store.registerLocal({ username: 'miner', password: 'secret', company: 'Nova Terra' });
+  assert.strictEqual(result.success, true);
+  const saved = JSON.parse(storage.getItem(STORAGE_KEYS.accounts));
+  assert.strictEqual(saved.length, 1);
+  assert.strictEqual(saved[0].username, 'miner');
+  assert.notStrictEqual(saved[0].password, 'secret');
+  assert.ok(saved[0].state);
+});
+
+test('registerLocal rejects duplicate usernames', () => {
+  const storage = new MemoryStorage({
+    [STORAGE_KEYS.accounts]: JSON.stringify([
+      { username: 'miner', password: 'hash', state: INITIAL_STATE() },
+    ]),
+  });
+  const store = new AccountStore(storage, null);
+  const result = store.registerLocal({ username: 'miner', password: 'secret', company: 'Nova Terra' });
+  assert.strictEqual(result.success, false);
+  assert.match(result.message, /Benutzername/);
+});
+
+test('loginLocal authenticates valid credentials and stores the active user', () => {
+  const storage = new MemoryStorage();
+  const store = new AccountStore(storage, null);
+  const account = { username: 'miner', password: store.hash('secret'), state: INITIAL_STATE() };
+  storage.setItem(STORAGE_KEYS.accounts, JSON.stringify([account]));
+  const result = store.loginLocal({ username: 'miner', password: 'secret' });
+  assert.strictEqual(result.success, true);
+  assert.strictEqual(storage.getItem(STORAGE_KEYS.active), 'miner');
+  assert.strictEqual(storage.getItem(STORAGE_KEYS.session), null);
+});
+
+test('loginLocal rejects invalid credentials', () => {
+  const storage = new MemoryStorage();
+  const store = new AccountStore(storage, null);
+  const account = { username: 'miner', password: store.hash('secret'), state: INITIAL_STATE() };
+  storage.setItem(STORAGE_KEYS.accounts, JSON.stringify([account]));
+  const result = store.loginLocal({ username: 'miner', password: 'wrong' });
+  assert.strictEqual(result.success, false);
+  assert.match(result.message, /Falsches Passwort/);
+});
+
+test('restoreActiveAccount returns the cached account when offline', async () => {
+  const storage = new MemoryStorage();
+  const store = new AccountStore(storage, null);
+  const account = { username: 'miner', password: store.hash('secret'), state: INITIAL_STATE() };
+  storage.setItem(STORAGE_KEYS.accounts, JSON.stringify([account]));
+  storage.setItem(STORAGE_KEYS.active, 'miner');
+  const restored = await store.restoreActiveAccount();
+  assert.ok(restored);
+  assert.strictEqual(restored.username, 'miner');
+});
+
+test('logout clears the active user and session tokens', async () => {
+  const storage = new MemoryStorage();
+  const store = new AccountStore(storage, null);
+  storage.setItem(STORAGE_KEYS.session, 'abc');
+  storage.setItem(STORAGE_KEYS.active, 'miner');
+  store.session = 'abc';
+  await store.logout();
+  assert.strictEqual(storage.getItem(STORAGE_KEYS.session), null);
+  assert.strictEqual(storage.getItem(STORAGE_KEYS.active), null);
+  assert.strictEqual(store.session, null);
+});

--- a/tests/gameEngine.test.mjs
+++ b/tests/gameEngine.test.mjs
@@ -1,0 +1,172 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { GameEngine, INITIAL_STATE, RESEARCH_DEFS } from '../assets/js/main.js';
+
+const createState = (overrides = {}) => {
+  const state = INITIAL_STATE();
+  if (overrides.credits !== undefined) state.credits = overrides.credits;
+  if (overrides.researchPoints !== undefined) state.researchPoints = overrides.researchPoints;
+  if (overrides.day !== undefined) state.day = overrides.day;
+  if (overrides.minuteOfDay !== undefined) state.minuteOfDay = overrides.minuteOfDay;
+  if (overrides.resources) {
+    state.resources = { ...state.resources, ...overrides.resources };
+  }
+  if (overrides.mines) state.mines = overrides.mines;
+  if (overrides.logistics) {
+    state.logistics = { ...state.logistics, ...overrides.logistics };
+  }
+  if (overrides.research) {
+    state.research = {
+      unlocked: overrides.research.unlocked ?? state.research.unlocked,
+      bonuses: { ...state.research.bonuses, ...(overrides.research.bonuses || {}) },
+    };
+  }
+  if (overrides.timeline) state.timeline = overrides.timeline;
+  return state;
+};
+
+const createGame = ({ stateOverrides = {}, multiplayer } = {}) => {
+  const state = createState(stateOverrides);
+  const account = {
+    username: 'miner',
+    company: 'Nova Terra',
+    state,
+    multiplayer: multiplayer || { guild: null, world: { topGuilds: [], events: [] } },
+  };
+  const updates = [];
+  const accountStore = {
+    updateAccount: (acc) => updates.push(acc),
+    remote: null,
+    session: null,
+  };
+  const toastMessages = [];
+  const toast = { show: (message) => toastMessages.push(message) };
+  const game = new GameEngine(account, accountStore, toast);
+  game.render = () => {};
+  return { game, updates, toastMessages };
+};
+
+test('advanceTime rolls over to a new day and notifies the account store', () => {
+  const { game, updates, toastMessages } = createGame({
+    stateOverrides: { minuteOfDay: 1430, day: 1 },
+  });
+  game.advanceTime(20);
+  assert.strictEqual(game.state.day, 2);
+  assert.ok(game.state.minuteOfDay < 60);
+  assert.strictEqual(updates.length, 1);
+  assert.strictEqual(updates[0], game.account);
+  assert.ok(toastMessages.at(-1)?.includes('Neuer Tag'));
+});
+
+test('dayPhaseMultiplier honors research stability and night ops technology', () => {
+  const multiplayer = {
+    guild: { technologies: [{ techId: 'night_ops' }] },
+    world: { topGuilds: [], events: [] },
+  };
+  const { game } = createGame({
+    stateOverrides: { minuteOfDay: 0, research: { bonuses: { stability: 0.5 } } },
+    multiplayer,
+  });
+  assert.strictEqual(game.dayPhaseMultiplier(), 0.8);
+});
+
+test('produceResources converts mine output into global resources', () => {
+  const mine = {
+    id: 'mine-1',
+    name: 'Aurora',
+    resource: 'iron',
+    workers: 60,
+    level: 1,
+    logisticsLevel: 1,
+    storage: 0,
+    baseStorage: 320,
+    location: { lat: 10, lng: 10 },
+  };
+  const { game } = createGame({
+    stateOverrides: {
+      mines: [mine],
+      logistics: { capacity: 1000 },
+      resources: { iron: 0 },
+    },
+  });
+  game.produceResources(60);
+  assert.ok(game.state.resources.iron > 0);
+  assert.ok(game.resourcesPerMinute.iron > 0);
+  assert.ok(mine.storage <= mine.baseStorage);
+});
+
+test('generateResearch accumulates research points over time', () => {
+  const { game } = createGame({ stateOverrides: { researchPoints: 100 } });
+  game.generateResearch(30);
+  assert.strictEqual(game.state.researchPoints, 124);
+});
+
+test('unlockResearch spends points, applies bonuses and records the unlock', () => {
+  const research = RESEARCH_DEFS.find((item) => item.id === 'automation');
+  const { game, toastMessages } = createGame({
+    stateOverrides: {
+      researchPoints: research.cost + 10,
+      research: { unlocked: [], bonuses: { production: 0 } },
+    },
+  });
+  game.unlockResearch(research);
+  assert.ok(game.state.research.unlocked.includes(research.id));
+  assert.strictEqual(game.state.researchPoints, 10);
+  assert.strictEqual(game.state.research.bonuses.production, research.bonusValue);
+  assert.ok(toastMessages.some((msg) => msg.includes('freigeschaltet')));
+});
+
+test('getGuildProductionModifier stacks zone bonuses, technologies and events', () => {
+  const polygon = [
+    [55, -5],
+    [55, 5],
+    [65, 5],
+    [65, -5],
+  ];
+  const multiplayer = {
+    guild: {
+      zones: [{ polygon, resourceBonus: 0.2 }],
+      technologies: [{ techId: 'synergy_drills' }],
+    },
+    world: {
+      topGuilds: [],
+      events: [
+        {
+          title: 'Polar Boost',
+          effect: { type: 'regionalBoost', region: 'Nordischer Gürtel', value: 0.15 },
+        },
+      ],
+    },
+  };
+  const { game } = createGame({ multiplayer });
+  const mine = { resource: 'iron', location: { lat: 60, lng: 0 } };
+  const modifier = game.getGuildProductionModifier(mine);
+  assert.ok(Math.abs(modifier - 1.43) < 1e-6);
+});
+
+test('getMarketMultiplier combines global tech and event modifiers', () => {
+  const multiplayer = {
+    guild: { technologies: [{ techId: 'global_market' }] },
+    world: {
+      topGuilds: [],
+      events: [
+        {
+          title: 'Iron Surge',
+          effect: { type: 'marketTrend', resource: ['iron'], value: 0.2 },
+        },
+      ],
+    },
+  };
+  const { game } = createGame({ multiplayer });
+  const multiplier = game.getMarketMultiplier('iron');
+  assert.ok(Math.abs(multiplier - 1.3) < 1e-6);
+});
+
+test('getLogisticsMultiplier reflects unlocked technologies', () => {
+  const multiplayer = {
+    guild: { technologies: [{ techId: 'global_market' }] },
+    world: { topGuilds: [], events: [] },
+  };
+  const { game } = createGame({ multiplayer });
+  assert.strictEqual(game.getLogisticsMultiplier(), 1.1);
+});

--- a/tests/validate_layout.py
+++ b/tests/validate_layout.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from html.parser import HTMLParser
+from pathlib import Path
+import sys
+
+INDEX_PATH = Path(__file__).resolve().parents[1] / 'index.html'
+
+class IdCollector(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.ids: dict[str, dict[str, object]] = {}
+        self.stack: list[tuple[str, str | None]] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str]]) -> None:
+        attr_dict = dict(attrs)
+        ancestor_ids = [entry_id for _, entry_id in self.stack if entry_id]
+        element_id = attr_dict.get('id')
+        if element_id:
+            self.ids[element_id] = {'tag': tag, 'ancestors': list(ancestor_ids), 'attrs': attr_dict}
+        self.stack.append((tag, element_id))
+
+    def handle_endtag(self, tag: str) -> None:
+        for index in range(len(self.stack) - 1, -1, -1):
+            stack_tag, _ = self.stack[index]
+            if stack_tag == tag:
+                del self.stack[index:]
+                break
+
+def fail(message: str) -> None:
+    print(f'Layout validation failed: {message}', file=sys.stderr)
+    sys.exit(1)
+
+def main() -> None:
+    if not INDEX_PATH.exists():
+        fail('index.html konnte nicht gefunden werden.')
+
+    html = INDEX_PATH.read_text(encoding='utf-8')
+
+    for marker in ('<<<<<<<', '=======', '>>>>>>>'):
+        if marker in html:
+            fail(f'Merge-Konflikt-Markierung "{marker}" gefunden.')
+
+    collector = IdCollector()
+    collector.feed(html)
+
+    required_ids = {
+        'app',
+        'game',
+        'map',
+        'status-window',
+        'mine-window',
+        'logistics-window',
+        'research-window',
+        'guild-window',
+        'community-window',
+        'world-events',
+        'world-guilds',
+        'open-login',
+        'open-register',
+        'open-game',
+        'auth-modal',
+        'login-form',
+        'register-form',
+        'mine-modal',
+        'mine-form',
+        'trade-resource',
+        'trade-sell',
+        'upgrade-logistics',
+        'save-game',
+        'logout',
+    }
+
+    missing = sorted(required_ids - collector.ids.keys())
+    if missing:
+        fail(f'Folgende IDs fehlen: {", ".join(missing)}')
+
+    ancestor_expectations = {
+        'world-events': 'community-window',
+        'world-guilds': 'community-window',
+        'mine-form': 'mine-modal',
+        'trade-resource': 'logistics-window',
+        'research-list': 'research-window',
+    }
+
+    for child_id, ancestor_id in ancestor_expectations.items():
+        info = collector.ids.get(child_id)
+        if not info:
+            fail(f'Element mit ID "{child_id}" wurde nicht gefunden.')
+        if ancestor_id not in info['ancestors']:
+            fail(f'Element "{child_id}" liegt nicht im erwarteten Bereich "{ancestor_id}".')
+
+    if 'class="window-body community-body"' not in html:
+        fail('Community-Fenster besitzt nicht die erwartete Layout-Klasse.')
+
+    hud_windows = [key for key in collector.ids if key.endswith('-window')]
+    if len(hud_windows) < 5:
+        fail('Es wurden weniger als fünf HUD-Fenster registriert.')
+
+    print('Layout validation passed.')
+
+ 
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- expose the game module's classes/constants for reuse and guard the browser bootstrap so it can be imported in tests
- add Node-based unit tests that cover account management flows and key GameEngine calculations
- introduce a layout validation script plus npm metadata to run the full check suite together

## Testing
- node -c assets/js/main.js
- node --test tests/accountStore.test.mjs
- node --test tests/gameEngine.test.mjs
- python tests/validate_layout.py

------
https://chatgpt.com/codex/tasks/task_e_68cafea97ee88322b3777df764eb161a